### PR TITLE
Simplify 'Mutable' class usage

### DIFF
--- a/clibb/Mutable.py
+++ b/clibb/Mutable.py
@@ -1,6 +1,22 @@
 from typing import Union
 
 class Mutable():
+    """
+    A container that holds a variable of type 'str', 'int' or 'float'.
+    The usually non-mutable types will become mutable because the container 
+    object is passed by reference and not by value.
+
+    If the 'message' parameter is of the same type ('Mutable'), 
+    it will simply return the parameter without modification.
+
+    If the 'message' parameter is of another type not mentioned before, 
+    it will raise a 'TypeError'.
+    """
+
+    def __new__(cls, message:  Union[float, int, str]) -> "Mutable":
+        if isinstance(message, (float, int, str)): return object.__new__(cls)
+        if isinstance(message, Mutable): return message
+        raise TypeError("'Mutable' must be instanciated with a parameter of type 'str', 'int' or 'float'")
 
     def __init__(self, message: Union[float, int, str]) -> None:
         self.set(message)
@@ -9,17 +25,18 @@ class Mutable():
     def __repr__(self) -> str: return str(self.__message)
     def __len__(self) -> int: return len(str(self))
 
-    def set(self, message: Union[float, int, str]):
+    def set(self, message: Union[float, int, str]) -> "Mutable":
+        """
+        Assign 'message' to this object and return the object.
+        """
         self.__check(message, float, int, str, Mutable)
         self.__message = str(message)
         return self
 
-    @classmethod
-    def new(cls, message):
-        if isinstance(message, Mutable): return message
-        return Mutable(message)
-
     def __check(self, message: Union[float, int, str], *types) -> None:
+        """
+        Throw error if 'message' is not a type of 'types'.
+        """
         for required_type in types:
             if isinstance(message, required_type): return
         raise TypeError(f"Expected {', '.join(required_type)}")

--- a/clibb/elements/Configuration.py
+++ b/clibb/elements/Configuration.py
@@ -6,11 +6,11 @@ from .Interactable import Interactable
 class Configuration(Element, Interactable):
 
     def __init__(self, variable: Union[Mutable, str], name: Union[Mutable, str], *options) -> None:
-        self.__variable = Mutable.new(variable)
-        self.__message = {"name": Mutable.new(name).set(f" {name}")}
+        self.__variable = Mutable(variable)
+        self.__message = {"name": Mutable(name).set(f" {name}")}
         temporary_list = []
         for option in options:
-            temporary_list.append(Mutable.new(option))
+            temporary_list.append(Mutable(option))
         self.__options = tuple(temporary_list)
         Interactable.__init__(self)
         Element.__init__(self)

--- a/clibb/elements/Display.py
+++ b/clibb/elements/Display.py
@@ -6,8 +6,8 @@ class Display(Element):
 
     def __init__(self, message: Union[Mutable, str], variable: Union[Mutable, str]) -> None:
         self.__message = {
-            "message_left": Mutable.new(message).set(f" {message}"), 
-            "message_right": Mutable.new(variable)
+            "message_left": Mutable(message).set(f" {message}"), 
+            "message_right": Mutable(variable)
             }
         super().__init__()
 

--- a/clibb/elements/Navigation.py
+++ b/clibb/elements/Navigation.py
@@ -7,14 +7,14 @@ class Navigation(Element):
     def __init__(self, abbreviation: Union[Mutable, str], name: Union[Mutable, str], variable: Union[Mutable, str] = None) -> None:
         if variable == None: 
             self.__message = {
-                "abbreviation": Mutable.new(abbreviation).set(f" {abbreviation} "), 
-                "name": Mutable.new(name).set(f" {name}")
+                "abbreviation": Mutable(abbreviation).set(f" {abbreviation} "), 
+                "name": Mutable(name).set(f" {name}")
                 }
         else:
             self.__message = {
-                "abbreviation": Mutable.new(abbreviation).set(f" {abbreviation} "), 
-                "name": Mutable.new(name).set(f" {name}"),
-                "variable": Mutable.new(variable)
+                "abbreviation": Mutable(abbreviation).set(f" {abbreviation} "), 
+                "name": Mutable(name).set(f" {name}"),
+                "variable": Mutable(variable)
                 }
         super().__init__()
 

--- a/clibb/elements/Title.py
+++ b/clibb/elements/Title.py
@@ -7,12 +7,12 @@ class Title(Element):
     def __init__(self, message_left: Union[Mutable, str], message_right: Union[Mutable, str] = None) -> None:
         if message_right == None:
             self.__message = {
-                "message_left": Mutable.new(message_left).set(f" {message_left} ")
+                "message_left": Mutable(message_left).set(f" {message_left} ")
             }
         else:
             self.__message = {
-                "message_left": Mutable.new(message_left).set(f" {message_left}"),
-                "message_right": Mutable.new(message_right).set(f"{message_right} ")
+                "message_left": Mutable(message_left).set(f" {message_left}"),
+                "message_right": Mutable(message_right).set(f"{message_right} ")
             }
         super().__init__()
 


### PR DESCRIPTION
Discovered the Python magic method **__new__()** which simplifies the usage of the **Mutable** class. No more _Mutable.new()_ is required to instantiate a **Mutable** object, with the condition of rejecting the instantiation in case of the parameter being another **Mutable** object.