### PR TITLE
Implement Text Input Element

### DIFF
--- a/clibb/Application.py
+++ b/clibb/Application.py
@@ -42,6 +42,9 @@ class Application():
             elif isinstance(window, dict): self.__windows.append(Window(window))
             elif isinstance(window, tuple) or isinstance(window, list): self.add(*window)
             else: raise TypeError("Elements of 'windows' must be of <class 'dict'> and/or <class 'Window'>")
+            elements = self.__windows[-1].get_elements()
+            for row, element in enumerate(elements):
+                element.set_row(row)
         if not len(self.__window_history): self.__add_to_history(0)
         
     def remove(self, *windows) -> None:

--- a/clibb/Window.py
+++ b/clibb/Window.py
@@ -29,6 +29,9 @@ class Window():
 
     def get_name(self) -> str:
         return self.__name
+    
+    def get_elements(self) -> list:
+        return self.__elements
 
     def run(self) -> dict:
         # Calculate console width if it has not been provided by user

--- a/clibb/__init__.py
+++ b/clibb/__init__.py
@@ -8,3 +8,4 @@ from .elements.Seperator import Seperator
 from .elements.Navigation import Navigation
 from .elements.Action import Action
 from .elements.Configuration import Configuration
+from .elements.Input import Input

--- a/clibb/elements/Configuration.py
+++ b/clibb/elements/Configuration.py
@@ -35,7 +35,7 @@ class Configuration(Element, Interactable):
         return message
 
     def __calculate_whitespaces_center(self, message: dict, width: int) -> str:
-        return " " * ((width // 3 - 2) - len(message["name"]))
+        return " " * ((width // 3 - 4) - len(message["name"]))
     
     def __center(self, word: str, desired_length):
         filling_character = " "

--- a/clibb/elements/Element.py
+++ b/clibb/elements/Element.py
@@ -4,7 +4,7 @@ from ..Color import Color
 class Element(ABC):
 
     def __init__(self) -> None:
-        pass
+        self.__row = None
 
     def reset_color(self, color: Color) -> str:
         return f"\33[0m\u001b[38;2;{color.r};{color.g};{color.b}m"
@@ -14,6 +14,12 @@ class Element(ABC):
 
     def draw_background(self, color: Color) -> str:
         return f"\u001b[48;2;{color.r};{color.g};{color.b}m"
+    
+    def get_row(self) -> int:
+        return self.__row
+    
+    def set_row(self, row: int) -> None:
+        self.__row = row
 
     @abstractclassmethod
     def display(self) -> None:

--- a/clibb/elements/Input.py
+++ b/clibb/elements/Input.py
@@ -1,0 +1,33 @@
+from typing import Union
+from ..Mutable import Mutable
+from .Element import Element
+from .Interactable import Interactable
+
+class Input(Element, Interactable):
+    
+    def __init__(self, variable: Union[Mutable, str], name: Union[Mutable, str]) -> None:
+        self.__variable = Mutable(variable)
+        self.__message = {"name": Mutable(name).set(f" {name}")}
+        self.__options = tuple([Mutable("...")])
+        self.__width = None
+        Interactable.__init__(self)
+        Element.__init__(self)
+        
+    def select(self, index: int) -> None:
+        moves_up = self.get_row() + 1
+        moves_forward = len(str(self.__message['name'])) + 3 + len(self.__calculate_whitespaces(self.__message, self.__width))
+        print(f"\x1b[{moves_up};{moves_forward}H\x1b[0K", end="")
+        user_input = input()
+        self.__variable.set(Mutable(f"{user_input}"))
+        self.__options = tuple([Mutable(f"{user_input}")])
+
+    def get_elements(self) -> list: return self.__options
+
+    def display(self, color_configuration: dict, width: int) -> str:
+        self.__width = width
+        message = f"{self.__message['name']}{self.__calculate_whitespaces(self.__message, width)}"
+        message += f"> {self.draw_background(color_configuration['pass']) if self.highlighted() != None else ''}"
+        return message + f"{self.__options[0]}{self.reset_color(color_configuration['text'])} "
+    
+    def __calculate_whitespaces(self, message: dict, width: int) -> str:
+        return " " * ((width // 3 - 4) - len(message["name"]))

--- a/clibb/elements/Seperator.py
+++ b/clibb/elements/Seperator.py
@@ -16,4 +16,4 @@ class Seperator(Element):
         else: return ""
 
     def __calculate_whitespaces(self, width: int) -> str:
-        return "_" * width
+        return "▁" * width

--- a/example.py
+++ b/example.py
@@ -7,6 +7,7 @@ class Settings():
     color_variable = clibb.Mutable("Option 2")
     menu_variable = clibb.Mutable("Option B")
     sound_variable = clibb.Mutable("Option IV")
+    message_variable = clibb.Mutable("Write below!")
 
 # Example Functions
 def generate_image() -> None:
@@ -32,13 +33,16 @@ window_1 = {
         clibb.Seperator("empty"),
         clibb.Navigation("c", "Configuration", Settings.sound_variable),
         clibb.Seperator("empty"),
+        clibb.Navigation("m", "Message", Settings.message_variable),
+        clibb.Seperator("empty"),
         clibb.Configuration(Settings.sound_variable, "Volume", "Option I", "Option II", "Option III", "Option IV"),
         clibb.Seperator("empty"),
         clibb.Navigation("k", "Code"),
-        clibb.Seperator("empty"),
         clibb.Navigation("t", "Text"),
         clibb.Seperator("empty"),
         clibb.Configuration(Settings.color_variable, "Color", "Option 1", "Option 2", "Option 3"),
+        clibb.Seperator("empty"),
+        clibb.Input(Settings.message_variable, "Write"),
         clibb.Seperator("empty"),
         clibb.Configuration(Settings.menu_variable, "Size", "Option A", "Option B"),
         clibb.Seperator("filled"),


### PR DESCRIPTION
CLIBB now supports text entry within the CLI in the form of (multiple) text input fields, diverging from the traditional command input at the bottom. Users can navigate between these new fields and the **Configuration** elements using the '**w**', '**a**', '**s**', '**d**' keys.
While with the **Configuration** element, pressing '**q**' selects the highlighted option, with **Input**, pressing '**q**' will position the cursor at the selected field, allowing users to utilize the entire line for text input. 