### PR TITLE
Expand Display Element for Callables

### DIFF
--- a/clibb/Mutable.py
+++ b/clibb/Mutable.py
@@ -1,42 +1,57 @@
-from typing import Union
+from typing import Union, Callable
 
-class Mutable():
+
+class Mutable:
     """
-    A container that holds a variable of type 'str', 'int' or 'float'.
-    The usually non-mutable types will become mutable because the container 
-    object is passed by reference and not by value.
-
-    If the 'message' parameter is of the same type ('Mutable'), 
-    it will simply return the parameter without modification.
-
-    If the 'message' parameter is of another type not mentioned before, 
-    it will raise a 'TypeError'.
+    A container that holds a value of type 'str', 'int', 'float', or a function
+    that evaluates to a 'str'-convertible value. The container allows
+    these usually non-mutable types to be mutable by reference.
     """
 
-    def __new__(cls, message:  Union[float, int, str]) -> "Mutable":
-        if isinstance(message, (float, int, str)): return object.__new__(cls)
-        if isinstance(message, Mutable): return message
-        raise TypeError("'Mutable' must be instanciated with a parameter of type 'str', 'int' or 'float'")
+    def __new__(cls, message: Union[float, int, str, Callable]) -> "Mutable":
+        if isinstance(message, (float, int, str, Callable)):
+            return object.__new__(cls)
+        if isinstance(message, Mutable):
+            return message
+        raise TypeError(
+            "'Mutable' must be instanciated with a parameter of type 'str', 'int', 'float' or 'callable'."
+        )
 
     def __init__(self, message: Union[float, int, str]) -> None:
         self.set(message)
-        
-    def __str__(self) -> str: return str(self.__message)
-    def __repr__(self) -> str: return str(self.__message)
-    def __len__(self) -> int: return len(str(self))
 
-    def set(self, message: Union[float, int, str]) -> "Mutable":
+    def __str__(self) -> str:
         """
-        Assign 'message' to this object and return the object.
+        Return a string representation of the contained value.
+        If the value is a callable, it evaluates and returns its string representation.
         """
-        self.__check(message, float, int, str, Mutable)
-        self.__message = str(message)
+        if isinstance(self.__message, Callable):
+            try:
+                result = str(self.__message())
+            except Exception as e:
+                raise ValueError(
+                    "Callable must return a string-convertible value."
+                ) from e
+            return result
+        return str(self.__message)
+
+    def __len__(self) -> int:
+        return len(str(self))
+
+    def set(self, message: Union[float, int, str, Callable]) -> "Mutable":
+        """
+        Assign a new value to this object and return the object.
+        """
+        self.__check(message, float, int, str, Callable, Mutable)
+        self.__message = str(message) if not callable(message) else message
         return self
 
-    def __check(self, message: Union[float, int, str], *types) -> None:
+    def __check(self, message: Union[float, int, str, Callable], *types) -> None:
         """
-        Throw error if 'message' is not a type of 'types'.
+        Check if 'message' is of a given type or types. Raise TypeError if not.
         """
-        for required_type in types:
-            if isinstance(message, required_type): return
-        raise TypeError(f"Expected {', '.join(required_type)}")
+        if not isinstance(message, types):
+            expected_types = ", ".join(t.__name__ for t in types)
+            raise TypeError(
+                f"Expected type(s): {expected_types}, got: {type(message).__name__}"
+            )

--- a/clibb/Window.py
+++ b/clibb/Window.py
@@ -5,86 +5,92 @@ from .elements.Action import Action
 from .elements.Interactable import Interactable
 import shutil
 
-class Window():
-    
+
+class Window:
     previous_message = None
     previous_line_written = None
 
-    def __init__(self, configuration: dict) -> None:
-        try:
-            self.__name = configuration["name"]
-            self.__elements = configuration["elements"]
-            self.__interactable_elements = [element for element in self.__elements if isinstance(element, Interactable)]
-            if self.__interactable_elements: self.__interactable_elements[0].highlight(0)
-            self.__color_configuration = configuration["colors"]
-            if "width" in configuration: self.width = configuration["width"]
-        except:
-            raise Warning("Please provide at least 'name', 'elements' and 'colors' for each window.")
+    def __init__(self, configuration):
+        self.__name = configuration.get("name")
+        self.__elements = configuration.get("elements", [])
+        self.__color_configuration = configuration.get("colors")
+        self.width = configuration.get("width", shutil.get_terminal_size().columns)
 
-    def __repr__(self) -> str:
+        self.__interactable_elements = [
+            element for element in self.__elements if isinstance(element, Interactable)
+        ]
+        if self.__interactable_elements:
+            self.__interactable_elements[0].highlight(0)
+
+        if not all([self.__name, self.__elements, self.__color_configuration]):
+            raise ValueError(
+                "Please provide at least 'name', 'elements' and 'colors' for each window."
+            )
+
+    def __str__(self):
         return self.__name
 
-    def __str__(self) -> str:
+    def get_name(self):
         return self.__name
 
-    def get_name(self) -> str:
-        return self.__name
-    
-    def get_elements(self) -> list:
+    def get_elements(self):
         return self.__elements
 
-    def run(self) -> dict:
-        # Calculate console width if it has not been provided by user
-        if hasattr(self, "width"): width = self.width
-        else: width = shutil.get_terminal_size().columns
-
+    def run(self):
         # Display every element of the active window
-        message = '\n'.join([element.display(self.__color_configuration, width) for element in self.__elements])
+        message = "\n".join(
+            [
+                element.display(self.__color_configuration, self.width)
+                for element in self.__elements
+            ]
+        )
 
         # If nothing has changed since the last user interaction, do not redraw window
-        if not Window.previous_message == message:
+        if Window.previous_message != message:
             self.__clear_console()
             print(message)
             Window.previous_message = message
             Window.previous_line_written = len(self.__elements)
 
         # Catch key press by user
-        try: user_input = self.__getch()
-        except: user_input = None
-
+        user_input = self.__getch()
         result = {"char": user_input, "name": None}
 
         # Perform specific actions only when specific user inputs and elements match
         for element in self.__elements:
             if isinstance(element, Action) and element.get_abbreviation() == user_input:
-                self.__clear_console()
+                if not element.get_stealth():
+                    self.__clear_console()
                 element.execute()
                 Window.previous_message = None
-            elif isinstance(element, Navigation) and element.get_abbreviation() == user_input:
+            elif (
+                isinstance(element, Navigation)
+                and element.get_abbreviation() == user_input
+            ):
                 result["name"] = element.get_name()
 
         Interactable.navigate(user_input, self.__interactable_elements)
         return result
 
-    def __getch(self) -> str:
-        try:
+    def __getch(self):
+        if os.name == "nt":
             import msvcrt
+
             return msvcrt.getch().decode()
-        except ImportError:
+        else:
             import termios
             import tty
+
             old_settings = termios.tcgetattr(sys.stdin)
             tty.setraw(sys.stdin)
             char = sys.stdin.read(1)
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
             return char
 
-    def __clear_console(self) -> None:
+    def __clear_console(self):
         # Properly clear the terminal on launch only
-        if Window.previous_line_written == None:
-            if os.name == 'nt': os.system('cls')
-            else: os.system('clear')
-            return
-        for index in range(Window.previous_line_written + 1):
-            print(end=f"\033[2K\r\33[A")
-            # print(end=f"\033[{index};1H")
+        if Window.previous_line_written is None:
+            os.system("cls" if os.name == "nt" else "clear")
+        else:
+            for _ in range(Window.previous_line_written + 1):
+                print(end="\033[2K\r\33[A")

--- a/clibb/elements/Action.py
+++ b/clibb/elements/Action.py
@@ -2,16 +2,39 @@ from typing import Union
 from ..Mutable import Mutable
 from .Navigation import Navigation
 
-class Action(Navigation):
-    
-    def __init__(self, 
-        abbreviation: Union[Mutable, str], name: Union[Mutable, str], 
-        variable: Union[Mutable, str] = None, action = None
-    ) -> None:
 
-        if not callable(action): raise TypeError("Expected a function")
+class Action(Navigation):
+
+    """
+    Element that, when activated, executes the function passed to it on initialization.
+    It makes sense to use the function of an object in order for you to be able
+    to store and further process the function's output.
+
+    Set 'stealth' to False if CLIBB should clear the console for you
+    and appear again after your function has finished executing.
+    """
+
+    def __init__(
+        self,
+        abbreviation: Union[Mutable, str],
+        name: Union[Mutable, str],
+        stealth=True,
+        action=None,
+    ) -> None:
+        if not callable(action):
+            raise TypeError("Expected a function")
         self.__action = action
-        super().__init__(abbreviation, name, variable)
+        self.__stealth = stealth
+        super().__init__(abbreviation, name, None)
+
+    def get_stealth(self) -> bool:
+        """
+        Get the current value of 'stealth'.
+        """
+        return self.__stealth
 
     def execute(self) -> any:
+        """
+        Execute the function passed to 'Action'.
+        """
         return self.__action()

--- a/clibb/elements/Display.py
+++ b/clibb/elements/Display.py
@@ -1,17 +1,25 @@
-from typing import Union
+from typing import Union, Callable
 from ..Mutable import Mutable
 from .Element import Element
 
+
 class Display(Element):
 
-    def __init__(self, message: Union[Mutable, str], variable: Union[Mutable, str]) -> None:
+    """
+    Element that displays text on the left side, followed by a variable value
+    on the right side.
+    """
+
+    def __init__(
+        self, message: Union[Mutable, str], variable: [Mutable, str, Callable]
+    ) -> None:
         self.__message = {
-            "message_left": Mutable(message).set(f" {message}"), 
-            "message_right": Mutable(variable)
-            }
+            "message_left": Mutable(message),
+            "message_right": Mutable(variable),
+        }
         super().__init__()
 
-    def display(self, color_configuration: dict, width: int) -> None:
+    def display(self, color_configuration: dict, width: int) -> str:
         message = str(self.__message["message_left"])
         message += self.__calculate_whitespaces(self.__message, width)
         message += str(self.__message["message_right"])

--- a/example.py
+++ b/example.py
@@ -1,7 +1,20 @@
 import clibb
 
+
+# Example Class
+class Person:
+    def __init__(self, name: str) -> None:
+        self.__name = name
+
+    def change_name(self) -> None:
+        self.__name = "Sophie"
+
+    def get_name(self) -> str:
+        return self.__name
+
+
 # Example Variables
-class Settings():
+class Settings:
     image_output_directory = clibb.Mutable("images")
     openai_status = clibb.Mutable("Running")
     color_variable = clibb.Mutable("Option 2")
@@ -9,10 +22,15 @@ class Settings():
     sound_variable = clibb.Mutable("Option IV")
     message_variable = clibb.Mutable("Write below!")
 
+
 # Example Functions
 def generate_image() -> None:
     Settings.openai_status.set("Changeable!")
     input("Wait...")
+
+
+# Example Object
+adult = Person("Hannah")
 
 # Example Windows
 window_1 = {
@@ -29,25 +47,38 @@ window_1 = {
         clibb.Title("CLIBB", "by Perytron with <3"),
         clibb.Seperator("empty"),
         clibb.Display("Service", Settings.openai_status),
+        clibb.Seperator("empty"),
+        clibb.Display("Name", adult.get_name),
         clibb.Seperator("filled"),
         clibb.Seperator("empty"),
         clibb.Navigation("c", "Configuration", Settings.sound_variable),
         clibb.Seperator("empty"),
         clibb.Navigation("m", "Message", Settings.message_variable),
         clibb.Seperator("empty"),
-        clibb.Configuration(Settings.sound_variable, "Volume", "Option I", "Option II", "Option III", "Option IV"),
+        clibb.Configuration(
+            Settings.sound_variable,
+            "Volume",
+            "Option I",
+            "Option II",
+            "Option III",
+            "Option IV",
+        ),
+        clibb.Seperator("empty"),
+        clibb.Action("o", "Name Change", action=adult.change_name, stealth=False),
         clibb.Seperator("empty"),
         clibb.Navigation("k", "Code"),
         clibb.Navigation("t", "Text"),
         clibb.Seperator("empty"),
-        clibb.Configuration(Settings.color_variable, "Color", "Option 1", "Option 2", "Option 3"),
+        clibb.Configuration(
+            Settings.color_variable, "Color", "Option 1", "Option 2", "Option 3"
+        ),
         clibb.Seperator("empty"),
         clibb.Input(Settings.message_variable, "Write"),
         clibb.Seperator("empty"),
         clibb.Configuration(Settings.menu_variable, "Size", "Option A", "Option B"),
         clibb.Seperator("filled"),
-        clibb.Seperator("empty")
-    ]
+        clibb.Seperator("empty"),
+    ],
 }
 
 window_2 = {
@@ -62,14 +93,14 @@ window_2 = {
     "elements": [
         clibb.Title("Configuration"),
         clibb.Seperator("empty"),
-        clibb.Action("g", "Generate", action = generate_image),
+        clibb.Action("g", "Generate", action=generate_image, stealth=False),
         clibb.Seperator("empty"),
         clibb.Navigation("h", "Home"),
         clibb.Seperator("empty"),
         clibb.Navigation("n", "No"),
         clibb.Seperator("filled"),
-        clibb.Seperator("empty")
-    ]
+        clibb.Seperator("empty"),
+    ],
 }
 
 console = clibb.Application()


### PR DESCRIPTION
I've lifted the restriction on using only the 'Mutable' type in the Display element. Now, it also accepts callables (i.e., functions) that return a string-representable value.

This enhancement broadens the scope for object modification. While the Action element can execute functions upon a button press, the Display element can now showcase (dynamically changed) object properties via its getter functions.