### PR TITLE
Refactor 'Configuration' 'options' for 'Checkbox' and 'Input' Compatibility

### DIFF
--- a/clibb/elements/Checkbox.py
+++ b/clibb/elements/Checkbox.py
@@ -12,16 +12,14 @@ class Checkbox(Element, Interactable):
     ) -> None:
         self.__message = {"name": Mutable(name).set(f" {name}")}
         self.__variable = Mutable(variable)
-        self.__options = tuple([Mutable("[X]")])
         Interactable.__init__(self)
         Element.__init__(self)
 
     def select(self, index: int) -> None:
         self.__variable.set(not self.__variable.unwrap())
-        self.__options = tuple([Mutable(self.__variable.unwrap)])
 
-    def get_elements(self) -> list:
-        return self.__options
+    def __len__(self) -> list:
+        return 1
 
     def display(self, color_configuration: dict, width: int) -> str:
         message = f"{self.__message['name']}{self.__calculate_whitespaces(self.__message, width)}"

--- a/clibb/elements/Configuration.py
+++ b/clibb/elements/Configuration.py
@@ -3,9 +3,11 @@ from ..Mutable import Mutable
 from .Element import Element
 from .Interactable import Interactable
 
-class Configuration(Element, Interactable):
 
-    def __init__(self, variable: Union[Mutable, str], name: Union[Mutable, str], *options) -> None:
+class Configuration(Element, Interactable):
+    def __init__(
+        self, variable: Union[Mutable, str], name: Union[Mutable, str], *options
+    ) -> None:
         self.__variable = Mutable(variable)
         self.__message = {"name": Mutable(name).set(f" {name}")}
         temporary_list = []
@@ -15,15 +17,17 @@ class Configuration(Element, Interactable):
         Interactable.__init__(self)
         Element.__init__(self)
 
-    def select(self, index: int) -> None: self.__variable.set(self.__options[index])
+    def select(self, index: int) -> None:
+        self.__variable.set(self.__options[index])
 
-    def get_elements(self) -> list: return self.__options
+    def __len__(self) -> list:
+        return len(self.__options)
 
     def display(self, color_configuration: dict, width: int) -> None:
-        message = str(self.__message['name'])
+        message = str(self.__message["name"])
         message += self.__calculate_whitespaces_center(self.__message, width)
         # field_width = (width - len(message) - (len(self.__options))) // len(self.__options)
-        field_width = 12 # WIP
+        field_width = 12  # WIP
         for index, option in enumerate(self.__options):
             if self.highlighted() == index:
                 message += self.draw_background(color_configuration["pass"])
@@ -36,7 +40,7 @@ class Configuration(Element, Interactable):
 
     def __calculate_whitespaces_center(self, message: dict, width: int) -> str:
         return " " * ((width // 3 - 4) - len(message["name"]))
-    
+
     def __center(self, word: str, desired_length):
         filling_character = " "
         required_space = desired_length - len(word)

--- a/clibb/elements/Input.py
+++ b/clibb/elements/Input.py
@@ -12,7 +12,6 @@ class Input(Element, Interactable):
     ) -> None:
         self.__variable = Mutable(variable)
         self.__message = {"name": Mutable(name).set(f" {name}")}
-        self.__options = tuple([Mutable("...")])
         self.__width = None
         Interactable.__init__(self)
         Element.__init__(self)
@@ -27,10 +26,9 @@ class Input(Element, Interactable):
         print(f"\x1b[{moves_up};{moves_forward}H\x1b[0K", end="")
         user_input = input()
         self.__variable.set(Mutable(f"{user_input}"))
-        self.__options = tuple([Mutable(f"{user_input}")])
 
-    def get_elements(self) -> list:
-        return self.__options
+    def __len__(self) -> list:
+        return 1
 
     def display(self, color_configuration: dict, width: int) -> str:
         self.__width = width
@@ -38,7 +36,7 @@ class Input(Element, Interactable):
         message += f"> {self.draw_background(color_configuration['pass']) if self.highlighted() != None else ''}"
         return (
             message
-            + f"{self.__options[0]}{self.reset_color(color_configuration['text'])} "
+            + f"{self.__variable}{self.reset_color(color_configuration['text'])} "
         )
 
     def __calculate_whitespaces(self, message: dict, width: int) -> str:


### PR DESCRIPTION
Initially designed for the '**Configuration**' element, '**options**' was practically incompatible with the newly implemented '**Checkbox**' and '**Input**' elements, hence it had to be altered.